### PR TITLE
feat: implement auction start/end time validation

### DIFF
--- a/app/Http/Controllers/BidController.php
+++ b/app/Http/Controllers/BidController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\AuctionItem;
 use App\Models\Bid;
+use App\Models\Setting;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -21,6 +22,22 @@ class BidController extends Controller
         if ($item->status !== 'active') {
             return back()->withErrors([
                 'amount' => 'This auction item is not currently accepting bids.',
+            ]);
+        }
+
+        // Validate auction timing
+        $settings = Setting::get();
+        $now = now();
+
+        if ($settings->auction_start && $now->lt($settings->auction_start)) {
+            return back()->withErrors([
+                'amount' => 'The auction has not started yet. Bidding opens at '.$settings->auction_start->format('M j, Y g:i A').'.',
+            ]);
+        }
+
+        if ($settings->auction_end && $now->gt($settings->auction_end)) {
+            return back()->withErrors([
+                'amount' => 'The auction has ended. Bidding closed at '.$settings->auction_end->format('M j, Y g:i A').'.',
             ]);
         }
 

--- a/resources/js/components/AuctionStatus.module.css
+++ b/resources/js/components/AuctionStatus.module.css
@@ -1,0 +1,71 @@
+.statusBanner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    margin-bottom: 1.5rem;
+    font-size: 0.875rem;
+}
+
+.statusBanner.active {
+    background-color: #ecfdf5;
+    border: 1px solid #10b981;
+    color: #065f46;
+}
+
+.statusBanner.inactive {
+    background-color: #fef2f2;
+    border: 1px solid #ef4444;
+    color: #991b1b;
+}
+
+.statusContent {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.icon {
+    width: 1.25rem;
+    height: 1.25rem;
+    flex-shrink: 0;
+}
+
+.statusText {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.statusLabel {
+    font-weight: 500;
+}
+
+.statusTime {
+    font-weight: 600;
+}
+
+.separator {
+    margin: 0 0.25rem;
+    color: currentColor;
+    opacity: 0.5;
+}
+
+@media (max-width: 640px) {
+    .statusBanner {
+        font-size: 0.8125rem;
+        padding: 0.625rem 0.875rem;
+    }
+
+    .statusText {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.25rem;
+    }
+
+    .separator {
+        display: none;
+    }
+}

--- a/resources/js/components/AuctionStatus.tsx
+++ b/resources/js/components/AuctionStatus.tsx
@@ -1,0 +1,80 @@
+import { type JSX } from "react";
+import { Clock } from "lucide-react";
+import styles from "./AuctionStatus.module.css";
+
+interface AuctionStatusProps {
+    auctionStart: string | null;
+    auctionEnd: string | null;
+}
+
+export function AuctionStatus({ auctionStart, auctionEnd }: AuctionStatusProps): JSX.Element | null {
+    // If no times are set, don't show anything
+    if (!auctionStart && !auctionEnd) {
+        return null;
+    }
+
+    const now = new Date();
+    const startDate = auctionStart ? new Date(auctionStart) : null;
+    const endDate = auctionEnd ? new Date(auctionEnd) : null;
+
+    const isBeforeStart = startDate && now < startDate;
+    const isAfterEnd = endDate && now > endDate;
+    const isActive = !isBeforeStart && !isAfterEnd;
+
+    const formatDate = (date: Date | null) => {
+        if (!date) return "";
+        return date.toLocaleString("en-US", {
+            month: "short",
+            day: "numeric",
+            year: "numeric",
+            hour: "numeric",
+            minute: "2-digit",
+            hour12: true,
+        });
+    };
+
+    return (
+        <div className={`${styles.statusBanner} ${isActive ? styles.active : styles.inactive}`}>
+            <div className={styles.statusContent}>
+                <Clock className={styles.icon} />
+                <div className={styles.statusText}>
+                    {isBeforeStart && startDate && (
+                        <div>
+                            <span className={styles.statusLabel}>Auction opens:</span>
+                            <span className={styles.statusTime}>{formatDate(startDate)}</span>
+                        </div>
+                    )}
+                    {isActive && (
+                        <div>
+                            <span className={styles.statusLabel}>Auction is open</span>
+                            {endDate && (
+                                <>
+                                    <span className={styles.separator}>•</span>
+                                    <span className={styles.statusLabel}>Closes:</span>
+                                    <span className={styles.statusTime}>{formatDate(endDate)}</span>
+                                </>
+                            )}
+                        </div>
+                    )}
+                    {isAfterEnd && endDate && (
+                        <div>
+                            <span className={styles.statusLabel}>Auction closed:</span>
+                            <span className={styles.statusTime}>{formatDate(endDate)}</span>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export function isAuctionActive(auctionStart: string | null, auctionEnd: string | null): boolean {
+    const now = new Date();
+    const startDate = auctionStart ? new Date(auctionStart) : null;
+    const endDate = auctionEnd ? new Date(auctionEnd) : null;
+
+    const isBeforeStart = startDate && now < startDate;
+    const isAfterEnd = endDate && now > endDate;
+
+    return !isBeforeStart && !isAfterEnd;
+}

--- a/resources/js/components/Bidder/AuctionItemCard.tsx
+++ b/resources/js/components/Bidder/AuctionItemCard.tsx
@@ -2,6 +2,7 @@ import { formatCurrency } from "@/lib/utils";
 import { AuctionItem, Bid, User } from "@/types";
 import { type JSX } from "react";
 import { Link } from "@inertiajs/react";
+import { isAuctionActive } from "@/components/AuctionStatus";
 import styles from "./AuctionItemCard.module.css";
 
 interface UserBidStatus {
@@ -15,6 +16,8 @@ interface AuctionItemCardProps {
     userBids: Bid[];
     onBidClick: (item: AuctionItem) => void;
     onBuyNowClick: (item: AuctionItem) => void;
+    auctionStart?: string | null;
+    auctionEnd?: string | null;
 }
 
 export default function AuctionItemCard({
@@ -22,7 +25,10 @@ export default function AuctionItemCard({
     userBids,
     onBidClick,
     onBuyNowClick,
+    auctionStart,
+    auctionEnd,
 }: AuctionItemCardProps): JSX.Element {
+    const isActive = isAuctionActive(auctionStart || null, auctionEnd || null);
     // Determine if user is winning or has been outbid for each item
     const getUserBidStatus = (itemId: number): UserBidStatus | null => {
         if (!userBids || userBids.length === 0) return null;
@@ -143,7 +149,9 @@ export default function AuctionItemCard({
                                 <div className={styles.buttonsContainer}>
                                     <button
                                         onClick={() => onBidClick(item)}
+                                        disabled={!isActive}
                                         className={`${styles.bidButton} ${userBidStatus && !userBidStatus.isWinning ? styles.bidButtonOutbid : userBidStatus && userBidStatus.isWinning ? styles.bidButtonWinning : ""}`}
+                                        title={!isActive ? "Auction is not currently active" : ""}
                                     >
                                         {userBidStatus && !userBidStatus.isWinning
                                             ? "Bid Again"

--- a/resources/js/pages/Home.tsx
+++ b/resources/js/pages/Home.tsx
@@ -5,6 +5,7 @@ import MobileNavigation from "@/components/MobileNavigation";
 import AuctionItemCard from "@/components/Bidder/AuctionItemCard";
 import BidModal from "@/components/Bidder/BidModal";
 import BuyNowModal from "@/components/Bidder/BuyNowModal";
+import { AuctionStatus } from "@/components/AuctionStatus";
 import { AuctionItem, Bid, PageProps } from "@/types";
 import styles from "./HomePage.module.css";
 import MyBids from "@/components/Bidder/MyBids";
@@ -58,6 +59,12 @@ export default function Home({ auth, auctionItems, userBids, settings }: HomePro
                 <main className={styles.main}>
                     {activeTab === "bidderDashboard" && (
                         <div className={styles.dashboardSection}>
+                            {/* Auction Status Banner */}
+                            <AuctionStatus
+                                auctionStart={settings.auction_start}
+                                auctionEnd={settings.auction_end}
+                            />
+
                             {/* Top section with filtering */}
                             <div className={styles.sectionHeader}>
                                 <div className={styles.titleRow}>
@@ -151,6 +158,8 @@ export default function Home({ auth, auctionItems, userBids, settings }: HomePro
                                     userBids={(userBids || []) as Bid[]}
                                     onBidClick={handleBidClick}
                                     onBuyNowClick={handleBuyNowClick}
+                                    auctionStart={settings.auction_start}
+                                    auctionEnd={settings.auction_end}
                                 />
                             )}
                         </div>


### PR DESCRIPTION
## Summary
Implements functional auction start and end time validation to control when users can place bids.

## Changes

### Backend
- Added time-based validation in `BidController::store()` method
- Checks `auction_start` and `auction_end` from settings before allowing bids
- Returns user-friendly error messages with formatted timestamps
- Prevents bid creation when auction hasn't started or has ended

### Frontend
- Created `AuctionStatus` component to display auction timing
  - Shows green banner when auction is active with close time
  - Shows red banner when auction hasn't started or has ended
  - Displays formatted start/end times
- Updated `AuctionItemCard` to disable bid buttons when auction is inactive
  - Added `isAuctionActive` utility function for status checking
  - Disabled buttons show tooltip explaining why
- Integrated auction status banner into Home page

## Technical Details
- Uses Laravel's `Setting::get()` singleton for accessing auction times
- Times are cast to Carbon datetime objects for comparison
- Frontend checks are client-side using JavaScript Date objects
- Consistent validation on both frontend (UX) and backend (security)

## Testing
- ✅ All linting checks pass (`bun lint`)
- Tested with:
  - Auction not started: bid button disabled, backend rejects bids
  - Auction active: bid button enabled, backend accepts bids
  - Auction ended: bid button disabled, backend rejects bids

## User Experience
Users now see clear visual indicators of auction status and cannot place bids outside the configured auction window. Error messages provide helpful information about when bidding opens/closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)